### PR TITLE
Fixed error when the owner or contact is not found on the 'View activity" page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro-apps/hubspot",
   "title": "HubSpot",
   "description": "Connect with HubSpot and view and update information from your CRM while in Deskpro tickets",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/pages/ActivityPage.tsx
+++ b/src/pages/ActivityPage.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo } from "react";
 import { useLocation } from "react-router-dom";
 import capitalize from "lodash/capitalize";
+import has from "lodash/has";
 import {
     LoadingSpinner,
     useDeskproElements,
@@ -53,13 +54,17 @@ const ActivityPage: FC = () => {
     const contacts = useQueriesWithClient(contactIds.data?.results?.map(({ id }) => ({
         queryKey: [QueryKey.CONTACT, id],
         queryFn: (client) => getContactService(client, id),
-        enabled: (contactIds.data?.results.length > 0)
+        enabled: (contactIds.data?.results.length > 0),
+        useErrorBoundary: false,
     })) ?? []);
 
     const owner = useQueryWithClient(
         [QueryKey.OWNERS, data?.properties?.hubspot_owner_id],
         (client) => getOwnerService(client, data?.properties?.hubspot_owner_id as string),
-        { enabled: !!data?.properties?.hubspot_owner_id }
+        {
+            enabled: has(data, ["properties", "hubspot_owner_id"]),
+            useErrorBoundary: false,
+        },
     );
 
     useSetAppTitle(!type ? "" : `${capitalize(type)} details`);


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/92536/hubspot-error-when-loading-call-details