### PR TITLE
Set default to current datetime when logging activity

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "title": "HubSpot",
   "description": "Connect with HubSpot and view and update information from your CRM while in Deskpro tickets",
   "appStoreUrl": "https://www.deskpro.com/product-embed/apps/hubspot",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/components/ActivityForm/utils.ts
+++ b/src/components/ActivityForm/utils.ts
@@ -31,7 +31,7 @@ const getInitValues = (
     return {
         activityType: getOption<string>("call", "Call"),
         description: "",
-        timestamp: "",
+        timestamp: new Date(),
         contacted: !contact
             ? getOption("", "")
             : getOption<Contact["id"]>(contact.value, contact.label),


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/97767/hubspot-default-to-current-datetime-when-logging-activity