### PR TITLE
[Feature] SC-132383 Pre-populate user information from Deskpro when creating new contact

### DIFF
--- a/src/pages/CreateContactPage/CreateContactPage.tsx
+++ b/src/pages/CreateContactPage/CreateContactPage.tsx
@@ -78,6 +78,7 @@ const CreateContactPage: FC = () => {
                 email: dpUser?.primaryEmail || "",
                 firstname: dpUser?.firstName || "",
                 lastname: dpUser?.lastName || "",
+                phone: dpUser?.phoneNumbers?.[0]?.number || "",
             }}
         />
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,13 @@ export type DeskproUser = {
     name: string,
     primaryEmail: string,
     titlePrefix: string,
+    phoneNumbers?: {
+        ext: string,
+        guessedType: string,
+        id: string
+        label: string,
+        number: string,
+    }[],
 };
 
 export type ContextData = {


### PR DESCRIPTION
Story: https://app.shortcut.com/deskpro/story/132383/hubspot-pre-populate-user-information-from-deskpro-when-creating-new-contact-in-hubspot-from-the-app

# Evidence
![image](https://github.com/user-attachments/assets/028f872c-93ce-4a67-86bd-4e51ed575867)
