### PR TITLE
[Bug] Sync Logout State Between Deskpro Tabs (SC-197710)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tippy.js": "^6.3.7",
     "ts-pattern": "^4.3.0",
     "use-debounce": "^8.0.4",
+    "use-local-storage-state": "^19.5.0",
     "uuid": "^11.1.0",
     "yup": "^0.32.11",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       use-debounce:
         specifier: ^8.0.4
         version: 8.0.4(react@18.3.1)
+      use-local-storage-state:
+        specifier: ^19.5.0
+        version: 19.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -3582,6 +3585,13 @@ packages:
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       react: '>=16.8.0'
+
+  use-local-storage-state@19.5.0:
+    resolution: {integrity: sha512-sUJAyFvsmqMpBhdwaRr7GTKkkoxb6PWeNVvpBDrLuwQF1PpbJRKIbOYeLLeqJI7B3wdfFlLLCBbmOdopiSTBOw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
 
   use-sync-external-store@1.5.0:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
@@ -7544,6 +7554,11 @@ snapshots:
   use-debounce@8.0.4(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  use-local-storage-state@19.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   use-sync-external-store@1.5.0(react@18.3.1):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "@sentry/react";
 import ViewCompanyPage from "./pages/companies/ViewCompanyPage/ViewCompanyPage";
 import CompanyIndexPage from "./pages/companies/CompanyIndexPage/CompanyIndexPage";
 import LinkCompanyPage from "./pages/companies/LinkCompanyPage/LinkCompanyPage";
+import { LogoutEventListener } from "./components";
 
 function App() {
   const { client } = useDeskproAppClient();
@@ -56,27 +57,46 @@ function App() {
         {({ reset }) => (
           <ErrorBoundary onReset={reset} fallback={ErrorFallback}>
             <Routes>
-              <Route path="/admin/mapping/contact" element={<ContactMappingPage />} />
-              <Route path="/admin/mapping/deal" element={<DealMappingPage />} />
-              <Route path="/admin/callback" element={<AdminCallbackPage />} />
-              <Route path="/home" element={<HomePage />} />
               <Route path="/login" element={<LoginPage />} />
-              <Route path="/link" element={<LinkPage />} />
-              <Route path="/deal/create" element={<CreateDealPage />} />
-              <Route path="/deal/update/:dealId" element={<UpdateDealPage />} />
-              <Route path="/deal/:dealId" element={<DealPage />} />
-              <Route path="/contacts/create" element={<CreateContactPage />} />
-              <Route path="/contacts/:contactId" element={<ViewContactPage />} />
-              <Route path="/contacts/edit/:contactId" element={<UpdateContactPage />} />
-              <Route path="/contacts/activities" element={<ActivityPage />} />
-              <Route path="/note/create" element={<CreateNotePage />} />
-              <Route path="/activity/create" element={<CreateActivityPage />} />
-              <Route path="/companies">
-                <Route path="link" element={<LinkCompanyPage />} />
-                <Route path=":companyId" element={<ViewCompanyPage />} />
-                <Route index element={<CompanyIndexPage />} />
+
+              <Route path="/admin">
+                <Route path="mapping">
+                  <Route path="contact" element={<ContactMappingPage />} />
+                  <Route path="deal" element={<DealMappingPage />} />
+                </Route>
+
+                <Route path="callback" element={<AdminCallbackPage />} />
               </Route>
-              <Route index element={<LoadingAppPage />} />
+
+              <Route element={<LogoutEventListener />}>
+                {/* Routes that require authentication (pretty much all routes besides login) should go here. */}
+                <Route index element={<LoadingAppPage />} />
+
+                <Route path="/home" element={<HomePage />} />
+                <Route path="/link" element={<LinkPage />} />
+                <Route path="/note/create" element={<CreateNotePage />} />
+                <Route path="/activity/create" element={<CreateActivityPage />} />
+
+                <Route path="/deal">
+                  <Route path="create" element={<CreateDealPage />} />
+                  <Route path="update/:dealId" element={<UpdateDealPage />} />
+                  <Route path=":dealId" element={<DealPage />} />
+                </Route>
+
+                <Route path="/contacts">
+                  <Route path="create" element={<CreateContactPage />} />
+                  <Route path=":contactId" element={<ViewContactPage />} />
+                  <Route path="activities" element={<ActivityPage />} />
+                  <Route path="edit/:contactId" element={<UpdateContactPage />} />
+                </Route>
+
+                <Route path="/companies">
+                  <Route path="link" element={<LinkCompanyPage />} />
+                  <Route path=":companyId" element={<ViewCompanyPage />} />
+                  <Route index element={<CompanyIndexPage />} />
+                </Route>
+              </Route>
+
             </Routes>
           </ErrorBoundary>
         )}

--- a/src/components/LogoutEventListener/LogoutEventListener.tsx
+++ b/src/components/LogoutEventListener/LogoutEventListener.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { useLogoutEvent } from "../../hooks";
+
+export default function LogoutEventListener() {
+  const { logoutEvent, setLogoutEvent } = useLogoutEvent()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (logoutEvent === true) {
+      // The login page resets the event.
+      navigate("/login");
+    }
+  }, [logoutEvent, navigate, setLogoutEvent]);
+
+  return (<>
+    <Outlet />
+  </>)
+}

--- a/src/components/LogoutEventListener/index.ts
+++ b/src/components/LogoutEventListener/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LogoutEventListener"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,4 +4,5 @@ export { CreateContact } from "./CreateContact";
 export { UpdateContact } from "./UpdateContact";
 export { CreateDeal } from "./CreateDeal";
 export { UpdateDeal } from "./UpdateDeal";
+export { default as LogoutEventListener } from "./LogoutEventListener"
 export * from "./Admin";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { default as useLogoutEvent } from "./useLogoutEvent";
 export { useAppContext, AppProvider } from "./AppContext";
 export { useAsyncError } from "./useAsyncError";
 export { useContact } from "./useContact";
@@ -11,5 +12,5 @@ export { useProperties } from "./useProperties";
 export { useQueriesWithClient } from "./useQueriesWithClient";
 export { useQueryWithClient } from "./useQueryWithClient";
 export { useSetAppTitle } from "./useSetAppTitle";
-export { useUnlinkContact } from "./useUnlinkContact";
 export { useUnlinkCompany } from "./useUnlinkCompany";
+export { useUnlinkContact } from "./useUnlinkContact";

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,11 +1,11 @@
 import { placeholders } from "../services/hubspot/constants";
 import { useCallback } from "react";
 import { useDeskproAppClient } from "@deskpro/app-sdk";
-import { useNavigate } from "react-router-dom";
+import useLogoutEvent from "./useLogoutEvent";
 
 export function useLogout() {
-    const navigate = useNavigate();
     const { client } = useDeskproAppClient();
+    const { setLogoutEvent } = useLogoutEvent()
 
     const logoutActiveUser = useCallback(() => {
         if (!client) {
@@ -15,11 +15,17 @@ export function useLogout() {
         client.setBadgeCount(0)
 
         client.deleteUserState(placeholders.OAUTH2_ACCESS_TOKEN_PATH)
-            .catch(() => { })
-            .finally(() => {
-                navigate("/login");
-            });
-    }, [client, navigate]);
+            .then(() => {
+
+                setLogoutEvent(true)
+            })
+            .catch((e) => {
+                const errorMessage = e instanceof Error && e.message.trim() !== "" ? e.message : "Unknown error"
+
+                // eslint-disable-next-line no-console
+                console.error(`Error logging out: `, errorMessage)
+            })
+    }, [client, setLogoutEvent]);
 
     return { logoutActiveUser };
 }

--- a/src/hooks/useLogoutEvent/index.ts
+++ b/src/hooks/useLogoutEvent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useLogoutEvent"

--- a/src/hooks/useLogoutEvent/useLogoutEvent.ts
+++ b/src/hooks/useLogoutEvent/useLogoutEvent.ts
@@ -1,0 +1,14 @@
+import useLocalStorageState from "use-local-storage-state";
+
+export default function useLogoutEvent() {
+
+  const [logoutEvent, setLogoutEvent] = useLocalStorageState<boolean | undefined>('hubSpot-logoutEvent', {
+    defaultValue: undefined,
+    storageSync: true
+  })
+
+  return {
+    logoutEvent,
+    setLogoutEvent
+  }
+}

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,8 +1,9 @@
 import { AnchorButton, H3, Stack } from "@deskpro/deskpro-ui"
 import { ErrorBlock } from "../../components/common"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { useDeskproElements, useInitialisedDeskproAppClient } from "@deskpro/app-sdk"
 import useLogin from "./useLogin"
+import { useLogoutEvent } from "../../hooks"
 
 const LoginPage: FC = () => {
     useDeskproElements(({ registerElement, clearElements }) => {
@@ -15,6 +16,16 @@ const LoginPage: FC = () => {
     }, [])
 
     const { onSignIn, authUrl, isLoading, error } = useLogin();
+
+    const { logoutEvent, setLogoutEvent } = useLogoutEvent()
+
+    useEffect(() => {
+        if (logoutEvent) {
+            setLogoutEvent(undefined)
+        }
+
+    }, [logoutEvent, setLogoutEvent])
+
 
     return (
         <Stack padding={12} vertical gap={12} role="alert">


### PR DESCRIPTION
## Description

This PR enables synching the logout state between tabs/windows so agents get redirected to the login page.

## Summary by Sourcery

Enable cross-tab logout synchronization using a shared local storage event and auto-redirect agents to the login page upon logout.

New Features:
- Broadcast logout events across browser tabs to trigger global logout redirects.

Enhancements:
- Introduce useLogoutEvent hook backed by use-local-storage-state and a LogoutEventListener component to listen for and react to logout events.
- Reorganize routing by grouping admin routes under '/admin' and wrapping all authenticated routes with the LogoutEventListener.

Build:
- Add 'use-local-storage-state' dependency to manage cross-tab state.