### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -153,7 +153,18 @@
       {
         "url": "https://api.hubapi.com/.*",
         "methods": ["GET", "POST", "PUT", "PATCH"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          },
+          "api_token": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }

--- a/src/services/hubspot/constants.ts
+++ b/src/services/hubspot/constants.ts
@@ -12,7 +12,7 @@ export const placeholders = {
     API_TOKEN: "__api_token__",
     OAUTH2_ACCESS_TOKEN_PATH: "oauth2/access_token",
     OAUTH2_REFRESH_TOKEN_PATH: "oauth2/refresh_token"
-};
+} as const;
 
 export const BASE_URL = "https://api.hubapi.com";
 
@@ -68,4 +68,4 @@ export const PROPERTIES = {
         "lifecyclestage",
     ],
     companies: ["name"],
-};
+} as const;


### PR DESCRIPTION
This pull request introduces improvements to the handling of HubSpot API authentication and constants in the codebase. The main focus is on enhancing configuration flexibility and enforcing immutability for constant objects.

**Authentication and configuration enhancements:**

* Updated the HubSpot API configuration in `manifest.json` to support dynamic injection of credentials (`client_id`, `client_secret`, and `api_token`) into request bodies and headers via the new `settingsInjection` property.

**Codebase consistency and safety:**

* Updated the `placeholders` and `PROPERTIES` constant objects in `src/services/hubspot/constants.ts` to use the `as const` assertion, ensuring that these objects are treated as immutable and their values are inferred as literal types. [[1]](diffhunk://#diff-a357ae90551d0db69be293b31de7f4d023ded47aa3e742c38d4948eeb22342bcL15-R15) [[2]](diffhunk://#diff-a357ae90551d0db69be293b31de7f4d023ded47aa3e742c38d4948eeb22342bcL71-R71)

## Summary by Sourcery

Improve app proxy security by configuring explicit credential injection points in the manifest and enforcing immutability of HubSpot constants

New Features:
- Add settingsInjection to manifest.json for dynamic injection of HubSpot credentials into request bodies and headers

Enhancements:
- Use 'as const' assertion on placeholders and PROPERTIES constants to enforce immutability and literal typing